### PR TITLE
close meta tags, add viewport-cover to handle screens with notches

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
     <title>Brandon Ayers | Inormation & CV</title>
 
 <script defer src="https://cloud.umami.is/script.js" data-website-id="36ba1462-d2b5-44fc-b0d6-250b2f3ba013"></script>


### PR DESCRIPTION
1. I doubt this is an issue, but at one point, self-closing tags needed an explicit `/>` to be considered closed. Adding that here for the `<meta>` tags _just in case_ it is the source of other weirdness.
2. Those white gutters on my phone should be fixed by the `safe-area-inset` stuff I mentioned yesterday, but I forgot it also needs `viewport-fit=cover` up here in the `<meta>` tags.