### PR TITLE
add open graph meta tags for shareability

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,25 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <meta property="og:type" content="profile" />
+    <meta property="og:title" content="Brandon Ayers | Information & CV" />
+    <meta property="og:url" content="https://brandonayers.com" />
+    <meta
+      property="og:image"
+      content="https://raw.githubusercontent.com/ohbrandon/ohbrandon.github.io/refs/heads/main/thumb.jpg"
+    />
+    <meta
+      property="og:description"
+      content="Phone Nerd, Academic Delinquent, Movie Snob"
+    />
+    <meta property="profile:first_name" content="Brandon" />
+    <meta property="profile:last_name" content="Ayers" />
+    <meta
+      property="profile:username"
+      content="https://www.linkedin.com/in/brandonayerss"
+    />
+
     <title>Brandon Ayers | Inormation & CV</title>
 
 <script defer src="https://cloud.umami.is/script.js" data-website-id="36ba1462-d2b5-44fc-b0d6-250b2f3ba013"></script>


### PR DESCRIPTION
You probably already know this, but when you share a URL on Slack, X, Facebook, etc, the nicely-formatted card that pops up is sometimes is because that site has Open Graph (OG) meta tags in the `<head>` of the page being shared. That meta information is freely used by platforms to create the little previews of the content without fetching the entire page. I generated OG tags for you using what felt like sane defaults, but feel free to customize or just not merge this at all.